### PR TITLE
No need to `nvm use` after `nvm install`

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -19,7 +19,6 @@ export NVM_DIR="/home/vagrant/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"  # This loads nvm
 
 nvm install 4.4.3
-nvm use 4.4.3
 npm i -g pre-gypify node-pre-gyp node-gyp
 node-gyp install 4.4.3
 


### PR DESCRIPTION
When you `nvm install 4`, there's no need to do a `nvm use` afterwards; it already starts using it. You can see in the output:

```
v4.4.3 is already installed.
Now using node v4.4.3 (npm v2.15.1)
Now using node v4.4.3 (npm v2.15.1)
```
