### PR TITLE
Build packages twice for node 4.5 and 6.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM buildpack-deps:jessie-scm
-ENV DOCKER_FILE_VERSION 0.0.1
+ENV DOCKER_FILE_VERSION 0.0.2
 
 WORKDIR /root/
 
 # cross compile toolchain
+# change DOCKER_FILE_VERSION to update this file
 RUN curl -s https://tessel-builds.s3.amazonaws.com/firmware/toolchain-mipsel.tar.gz | tar -xz
 
 RUN apt-get update \
@@ -11,13 +12,22 @@ RUN apt-get update \
   && apt-get autoremove -y \
   && apt-get clean -y
 
-# Install node 4x
-ENV NODE_VERSION 4.5.0
-RUN curl -s https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.gz | tar -xz
-ENV PATH $PATH:/root/node-v${NODE_VERSION}-linux-x64/bin
+# Install NVM
+RUN ["/bin/bash", "-c", "curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.32.0/install.sh | bash"]
 
-RUN npm install -g pre-gypify node-pre-gyp node-gyp \
-  && node-gyp install $NODE_VERSION
+# Install node 4.5.0
+RUN ["/bin/bash", "-c", ". /root/.nvm/nvm.sh \
+  && nvm install 4.5.0 \
+  && npm install -g pre-gypify node-pre-gyp node-gyp \
+  && node-gyp install 4.5.0 \
+  "]
+
+# Install node 6.5.0
+RUN ["/bin/bash", "-c", ". /root/.nvm/nvm.sh \
+  && nvm install 6.5.0 \
+  && npm install -g pre-gypify node-pre-gyp node-gyp \
+  && node-gyp install 6.5.0 \
+  "]
 
 COPY ./compile.sh /root/
 ENTRYPOINT ["/root/compile.sh"]

--- a/README.md
+++ b/README.md
@@ -56,13 +56,6 @@ docker images
 docker run --rm -v `pwd`/out:/out t2-compiler:dev serialport@4.0.0 /out
 ```
 
-Master is automatically built and pushed by the docker-hub service with our tessel account. It's the equivalent of;
-
-```bash
-docker build -t tessel/t2-compiler ./
-docker push tessel/t2-compiler
-```
-
 To get an interactive shell run
 ```
 # from docker hub
@@ -71,3 +64,9 @@ docker run -it --rm --entrypoint bash tessel/t2-compiler
 docker run -it --rm --entrypoint bash t2-compiler:dev
 ```
 
+Master is automatically built and pushed by the docker-hub service with our tessel account. It's the equivalent of;
+
+```bash
+docker build -t tessel/t2-compiler ./
+docker push tessel/t2-compiler
+```

--- a/compile-docker.sh
+++ b/compile-docker.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 set -ex
-docker run --rm -v `pwd`/out:/out tessel/t2-compiler $1 /out
+docker run --rm -v `pwd`/out:/out tessel/t2-compiler $1 /out 4.5.0
+docker run --rm -v `pwd`/out:/out tessel/t2-compiler $1 /out 6.5.0

--- a/compile-vagrant.sh
+++ b/compile-vagrant.sh
@@ -10,4 +10,5 @@ fi
 
 cd $(dirname $0)
 mkdir -p ./out
-vagrant ssh -c "sudo su root /root/compile.sh $PACKAGE_NAME /root/out/"
+vagrant ssh -c "sudo su root /root/compile.sh $PACKAGE_NAME /root/out/ 4.5.0"
+vagrant ssh -c "sudo su root /root/compile.sh $PACKAGE_NAME /root/out/ 6.5.0"

--- a/compile.sh
+++ b/compile.sh
@@ -3,6 +3,10 @@ set -e
 
 PACKAGE_NAME=$1
 OUTPUT_DIR=$2
+. /root/.nvm/nvm.sh
+[ -n "$3" ] && nvm use $3
+NODE_VERSION=`node -p process.versions.node`
+
 ARCH=mipsel
 export STAGING_DIR=/root
 
@@ -16,8 +20,6 @@ if [ ! -d "$OUTPUT_DIR" ]; then
   (>&2 echo "ERROR: The output directory ${OUTPUT_DIR} doesn't exist")
   exit 1
 fi
-
-: "${NODE_VERSION?Need to set the env var NODE_VERSION}"
 
 cd $(dirname $0)
 


### PR DESCRIPTION
./compile-docker.sh and ./compile-vagrant.sh now produce 4 binaries Debug and Release for node 4.5 and node 6.5.

User NVM under the hood, and preinstalls the required packages. The compile.sh script requires that nvm be installed for root, that node-pre-gyp, node-gyp, and node-gyp be installed, and that node-gyp has the header files for each version of node installed.

Vagrant also needed more ram for npm3. Please destroy and rebuild machines.

Smoke tests:

Vagrant

```
vagrant destroy -f
vagrant up
./compile-vagrant.sh serialport
```

Docker

```
docker build ./ -t t2-compiler:dev
# equivalent to ./compile-docker.sh serialport but uses the local image instead of the public one
docker run --rm -v `pwd`/out:/out t2-compiler:dev serialport /out 4.5.0
docker run --rm -v `pwd`/out:/out t2-compiler:dev serialport /out 6.5.0
```
