### PR TITLE
Allow release builds to be compiled while ignoring debug builds.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 out
 *.conf
 node_modules
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 out
 *.conf
 node_modules
-.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update \
   && apt-get clean -y
 
 # Install NVM
-RUN ["/bin/bash", "-c", "curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.32.0/install.sh | bash"]
+RUN ["/bin/bash", "-c", "curl -s -o - https://raw.githubusercontent.com/creationix/nvm/v0.32.0/install.sh | bash"]
 
 # Install node 4.5.0
 RUN ["/bin/bash", "-c", ". /root/.nvm/nvm.sh \

--- a/compile-docker.sh
+++ b/compile-docker.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 set -ex
-docker run --rm -v `pwd`/out:/out tessel/t2-compiler $1 /out 4.5.0
-docker run --rm -v `pwd`/out:/out tessel/t2-compiler $1 /out 6.5.0
+docker run --rm -v `pwd`/out:/out tessel/t2-compiler $1 /out 4.5.0 release
+docker run --rm -v `pwd`/out:/out tessel/t2-compiler $1 /out 6.5.0 release
+docker run --rm -v `pwd`/out:/out tessel/t2-compiler $1 /out 4.5.0 debug
+docker run --rm -v `pwd`/out:/out tessel/t2-compiler $1 /out 6.5.0 debug

--- a/compile-vagrant.sh
+++ b/compile-vagrant.sh
@@ -10,5 +10,7 @@ fi
 
 cd $(dirname $0)
 mkdir -p ./out
-vagrant ssh -c "sudo su root /root/compile.sh $PACKAGE_NAME /root/out/ 4.5.0"
-vagrant ssh -c "sudo su root /root/compile.sh $PACKAGE_NAME /root/out/ 6.5.0"
+vagrant ssh -c "sudo su root /root/compile.sh $PACKAGE_NAME /root/out/ 4.5.0 release"
+vagrant ssh -c "sudo su root /root/compile.sh $PACKAGE_NAME /root/out/ 6.5.0 release"
+vagrant ssh -c "sudo su root /root/compile.sh $PACKAGE_NAME /root/out/ 4.5.0 debug"
+vagrant ssh -c "sudo su root /root/compile.sh $PACKAGE_NAME /root/out/ 6.5.0 debug"

--- a/compile.sh
+++ b/compile.sh
@@ -5,7 +5,7 @@ PACKAGE_NAME=$1
 OUTPUT_DIR=$2
 . /root/.nvm/nvm.sh
 [ -n "$3" ] && nvm use $3
-USE_DEBUG=$4
+RELEASE_TYPE=$4
 NODE_VERSION=`node -p process.versions.node`
 
 ARCH=mipsel
@@ -66,7 +66,7 @@ set -x
 npm install --ignore-scripts # 2>1 >/dev/null
 pre-gypify --package_name "{name}-{version}-{configuration}-{node_abi}-{platform}-{arch}.tgz"
 
-if [[ $USE_DEBUG == "debug" ]]; then
+if [[ $RELEASE_TYPE == "debug" ]]; then
   echo "Debug build"
   node-pre-gyp rebuild --target_platform=linux --target_arch=$ARCH --target=$NODE_VERSION --debug
   node-pre-gyp package --target_platform=linux --target_arch=$ARCH --target=$NODE_VERSION --debug

--- a/compile.sh
+++ b/compile.sh
@@ -5,6 +5,7 @@ PACKAGE_NAME=$1
 OUTPUT_DIR=$2
 . /root/.nvm/nvm.sh
 [ -n "$3" ] && nvm use $3
+USE_DEBUG=$4
 NODE_VERSION=`node -p process.versions.node`
 
 ARCH=mipsel
@@ -65,12 +66,14 @@ set -x
 npm install --ignore-scripts # 2>1 >/dev/null
 pre-gypify --package_name "{name}-{version}-{configuration}-{node_abi}-{platform}-{arch}.tgz"
 
-echo "Release build"
-node-pre-gyp rebuild --target_platform=linux --target_arch=$ARCH --target=$NODE_VERSION
-node-pre-gyp package --target_platform=linux --target_arch=$ARCH --target=$NODE_VERSION
-mv -vn build/stage/*.tgz $OUTPUT_DIR
-
-echo "Debug build"
-node-pre-gyp rebuild --target_platform=linux --target_arch=$ARCH --target=$NODE_VERSION --debug
-node-pre-gyp package --target_platform=linux --target_arch=$ARCH --target=$NODE_VERSION --debug
-mv -vn build/stage/*.tgz $OUTPUT_DIR
+if [[ $USE_DEBUG == "debug" ]]; then
+  echo "Debug build"
+  node-pre-gyp rebuild --target_platform=linux --target_arch=$ARCH --target=$NODE_VERSION --debug
+  node-pre-gyp package --target_platform=linux --target_arch=$ARCH --target=$NODE_VERSION --debug
+  mv -vn build/stage/*.tgz $OUTPUT_DIR
+else
+  echo "Release build"
+  node-pre-gyp rebuild --target_platform=linux --target_arch=$ARCH --target=$NODE_VERSION
+  node-pre-gyp package --target_platform=linux --target_arch=$ARCH --target=$NODE_VERSION
+  mv -vn build/stage/*.tgz $OUTPUT_DIR
+fi


### PR DESCRIPTION
Allow us to compile packages like `grpc` which fail on debug but succeed on release. We simply compile release packages for all ABI versions first, then try to compile debug packages.

Because we use debug builds so rarely, and upstream packages don't seem to test them often, this ordering allows us to at least provide a partial solution until affected packages are fixed. See #36 for some details on this.
